### PR TITLE
fix: handle mouse wheel event gracefully to prevent errors when canvas is destroyed

### DIFF
--- a/transcribe.py
+++ b/transcribe.py
@@ -652,7 +652,14 @@ def _open_settings():
     canvas.bind("<Configure>", _on_canvas_configure)
 
     def _on_mousewheel(event):
-        canvas.yview_scroll(int(-1 * (event.delta / 120)), "units")
+        try:
+            canvas.yview_scroll(int(-1 * (event.delta / 120)), "units")
+        except tk.TclError:
+            pass  # Canvas has been destroyed; unbind to stop further calls
+            try:
+                canvas.unbind_all("<MouseWheel>")
+            except tk.TclError:
+                pass
     canvas.bind_all("<MouseWheel>", _on_mousewheel)
 
     pad = {"padx": (20, 20)}


### PR DESCRIPTION
## Summary

Fixes a `TclError` that occurs when the mouse wheel event fires after the settings dialog canvas has already been destroyed.

## Changes

- Wrapped the `canvas.yview_scroll()` call in a `try/except TclError` block to gracefully handle the case where the canvas widget no longer exists.
- On the first such error, unbinds the `<MouseWheel>` event globally to prevent further spurious calls.

## Files Changed

- `transcribe.py` — Updated `_on_mousewheel` handler in `_open_settings()`