### PR TITLE
Stabilize macOS capture flow and add multilingual session selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,11 @@ Use `env.sample` as the source of truth. Important settings:
 ### Identity and language
 
 - `YOUR_NAME` - your speaker label in transcript
-- `LANGUAGE` - transcription language code (for example `en`, `lv`)
+- `LANGUAGE` - transcription language code(s):
+  - single code: `en`
+  - comma-separated list: `en,no,lv`
+  - when multiple codes are configured, manual `Start` prompts you to pick one language for that recording session
+  - with `AUTO_START_TRANSCRIPTION=True`, the app uses the first configured language automatically (no prompt)
 
 ### Session behavior
 
@@ -124,7 +128,7 @@ Use `env.sample` as the source of truth. Important settings:
 The app settings dialog allows runtime updates and persists them to `.env`:
 
 - Auto-start transcription
-- Transcription language
+- Transcription language(s) (single code or comma-separated list)
 - Auto-summarize on stop
 - Enable internet search for assistant custom prompts
 - Transcriptions folder

--- a/audio_capture.py
+++ b/audio_capture.py
@@ -74,87 +74,116 @@ def collect_from_stream(
 	logger,
 ):
 	logger.info("[%s] Starting collect_from_stream...", input_device["name"])
+	stream = None
 	try:
 		frame_rate = int(input_device["defaultSampleRate"])
 		chunk_size = int(frame_rate * frame_duration_ms / 1000)
 		if chunk_size <= 0:
 			chunk_size = 1
 
-		with p_instance.open(
+		input_channels = int(input_device.get("maxInputChannels", 0) or 0)
+		if input_channels <= 0:
+			logger.warning(
+				"[%s] Device has no input channels; skipping capture for this device.",
+				input_device.get("name", "Unknown"),
+			)
+			return
+
+		stream = p_instance.open(
 			format=p_instance.get_format_from_width(2),
-			channels=input_device["maxInputChannels"],
+			channels=input_channels,
 			rate=frame_rate,
 			frames_per_buffer=chunk_size,
 			input=True,
 			input_device_index=input_device["index"],
-		) as stream:
-			logger.info("[%s] Audio stream opened successfully.", input_device["name"])
-			frames = []
-			start_time = time.time()
-			silence_start_time = None
-			silence_frame_count = 0
+		)
+		logger.info("[%s] Audio stream opened successfully.", input_device["name"])
+		frames = []
+		start_time = time.time()
+		silence_start_time = None
+		silence_frame_count = 0
 
-			while not stop_event.is_set():
-				try:
-					if len(frames) == silence_frame_count:
-						start_time = time.time()
+		while not stop_event.is_set():
+			try:
+				if len(frames) == silence_frame_count:
+					start_time = time.time()
 
-					if from_microphone and mute_mic_event.is_set():
-						time.sleep(0.001)
-						continue
+				if from_microphone and mute_mic_event.is_set():
+					time.sleep(0.001)
+					continue
 
-					data = stream.read(chunk_size, exception_on_overflow=False)
-					frames.append(data)
+				data = stream.read(chunk_size, exception_on_overflow=False)
+				frames.append(data)
 
-					with flush_lock:
-						flush_mic, flush_out = get_flush_letters()
-						current_letter = flush_mic if from_microphone else flush_out
-						clear_flush_letters(from_microphone)
+				with flush_lock:
+					flush_mic, flush_out = get_flush_letters()
+					current_letter = flush_mic if from_microphone else flush_out
+					clear_flush_letters(from_microphone)
 
-					if current_letter:
-						if len(frames) > 0:
-							if current_letter == "_" and not from_microphone:
-								seconds_to_go_back = 2.0
-								frames_to_remove = int((1000 / frame_duration_ms) * seconds_to_go_back)
-								frames_to_process = frames[:-frames_to_remove]
-								previous_speaker, _ = speaker_snapshot_getter()
-								queue.put((frames_to_process.copy(), previous_speaker, start_time))
-								frames = frames[-frames_to_remove:]
-								start_time = time.time() - (frames_to_remove * frame_duration_ms) / 1000
-							elif current_letter != "_":
-								logger.info("[%s] Manual split triggered; flushing %s frames.", input_device["name"], len(frames))
-								speaker_setter(current_letter)
-								queue.put((frames.copy(), current_letter, start_time))
-								frames = []
-							silence_frame_count = 0
-
-					audio_samples = np.array(struct.unpack(f"{len(data)//2}h", data))
-					volume = np.sqrt(np.mean(audio_samples ** 2))
-
-					if volume < silence_threshold:
-						silence_frame_count += 1
-						if silence_start_time is None:
-							silence_start_time = time.time()
-						elif time.time() - silence_start_time >= silence_duration:
-							if len(frames) != silence_frame_count:
-								_, current_speaker = speaker_snapshot_getter()
-								queue.put((frames.copy(), current_speaker, start_time))
+				if current_letter:
+					if len(frames) > 0:
+						if current_letter == "_" and not from_microphone:
+							seconds_to_go_back = 2.0
+							frames_to_remove = int((1000 / frame_duration_ms) * seconds_to_go_back)
+							frames_to_process = frames[:-frames_to_remove]
+							previous_speaker, _ = speaker_snapshot_getter()
+							queue.put((frames_to_process.copy(), previous_speaker, start_time))
+							frames = frames[-frames_to_remove:]
+							start_time = time.time() - (frames_to_remove * frame_duration_ms) / 1000
+						elif current_letter != "_":
+							logger.info("[%s] Manual split triggered; flushing %s frames.", input_device["name"], len(frames))
+							speaker_setter(current_letter)
+							queue.put((frames.copy(), current_letter, start_time))
 							frames = []
-							silence_frame_count = 0
-							silence_start_time = None
-					else:
-						silence_start_time = None
+						silence_frame_count = 0
 
-					if len(frames) >= int((frame_rate * record_seconds) / chunk_size):
-						logger.info("[%s] Auto split after reaching %s seconds; queueing %s frames.", input_device["name"], record_seconds, len(frames))
-						_, current_speaker = speaker_snapshot_getter()
-						queue.put((frames.copy(), current_speaker, start_time))
+				audio_samples = np.array(struct.unpack(f"{len(data)//2}h", data))
+				volume = np.sqrt(np.mean(audio_samples ** 2))
+
+				if volume < silence_threshold:
+					silence_frame_count += 1
+					if silence_start_time is None:
+						silence_start_time = time.time()
+					elif time.time() - silence_start_time >= silence_duration:
+						if len(frames) != silence_frame_count:
+							_, current_speaker = speaker_snapshot_getter()
+							queue.put((frames.copy(), current_speaker, start_time))
 						frames = []
 						silence_frame_count = 0
-				except Exception as e:
-					logger.warning("[%s] Error reading from stream: %s", input_device["name"], e)
-					break
+						silence_start_time = None
+				else:
+					silence_start_time = None
+
+				if len(frames) >= int((frame_rate * record_seconds) / chunk_size):
+					logger.info("[%s] Auto split after reaching %s seconds; queueing %s frames.", input_device["name"], record_seconds, len(frames))
+					_, current_speaker = speaker_snapshot_getter()
+					queue.put((frames.copy(), current_speaker, start_time))
+					frames = []
+					silence_frame_count = 0
+			except Exception as e:
+				logger.warning("[%s] Error reading from stream: %s", input_device["name"], e)
+				break
+
+		if frames:
+			_, current_speaker = speaker_snapshot_getter()
+			queue.put((frames.copy(), current_speaker, start_time))
+			logger.info(
+				"[%s] Flushed %s buffered frames on stop.",
+				input_device["name"],
+				len(frames),
+			)
 	except Exception as e:
 		logger.error("[%s] Failed to open audio stream: %s", input_device.get("name", "Unknown"), e)
+	finally:
+		if stream is not None:
+			try:
+				if stream.is_active():
+					stream.stop_stream()
+			except Exception:
+				pass
+			try:
+				stream.close()
+			except Exception:
+				pass
 
 	logger.info("[%s] collect_from_stream exiting.", input_device.get("name", "Unknown"))

--- a/env.sample
+++ b/env.sample
@@ -1,4 +1,5 @@
 YOUR_NAME=John
+# Single code (en) or comma-separated list (en,no,lv)
 LANGUAGE=en
 INTERUPT_MANUALLY=True
 AUTO_START_TRANSCRIPTION=False

--- a/env_utils.py
+++ b/env_utils.py
@@ -49,3 +49,35 @@ def env_bool(env: dict[str, str], name: str, default: bool, warnings: list[str])
 
     warnings.append(f"Invalid boolean for {name}='{raw}'. Using default {default}.")
     return default
+
+
+def parse_language_candidates(
+    raw: Optional[str],
+    supported_languages: list[str],
+    warnings: list[str],
+    fallback: str = "en",
+) -> list[str]:
+    value = (raw or "").strip().lower()
+    if not value:
+        return [fallback]
+
+    seen: set[str] = set()
+    candidates: list[str] = []
+    for token in value.split(","):
+        code = token.strip().lower()
+        if not code:
+            continue
+        if code not in supported_languages:
+            warnings.append(f"LANGUAGE includes unsupported code '{code}'. Ignoring it.")
+            continue
+        if code in seen:
+            continue
+        seen.add(code)
+        candidates.append(code)
+
+    if not candidates:
+        warnings.append(
+            f"LANGUAGE='{raw}' has no supported codes. Using '{fallback}'."
+        )
+        return [fallback]
+    return candidates

--- a/run_transcribe_mac.sh
+++ b/run_transcribe_mac.sh
@@ -1,44 +1,43 @@
 #!/bin/bash
+set -u
 
-e# Check if virtual environment exists
-if [ ! -d ".venv" ]; then
-    echo "Virtual environment not found in project directory."
-    echo "Checking if Poetry has a virtual environment configured..."
-    if ! poetry env info >/dev/null 2>&1; then
-        echo "ERROR: No virtual environment found."
-        echo "Please run ./first_time_install_mac.sh to set up the project."
-        exit 1
-    else
-        echo "Found Poetry virtual environment outside project directory."
-        echo "This will still work, but consider running ./first_time_install_mac.sh"
-        echo "to create a local .venv folder for easier management."
-        echo
-    fi
-fi=============================================="
+# Run from repo root regardless of caller's current directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR" || exit 1
+
+echo "==============================================="
 echo "Starting transcribe application"
 echo "==============================================="
 echo
 
 # Check if Poetry is available
-if ! command -v poetry &> /dev/null; then
+if ! command -v poetry >/dev/null 2>&1; then
     echo "ERROR: Poetry is not installed or not in PATH."
     echo "Please run ./first_time_install_mac.sh to set up the project."
     exit 1
 fi
 
-# Check if virtual environment exists
-if [ ! -d ".venv" ]; then
-    echo "ERROR: Virtual environment not found."
+# Check if Poetry has an environment configured
+if ! poetry env info >/dev/null 2>&1; then
+    echo "ERROR: No Poetry virtual environment found."
     echo "Please run ./first_time_install_mac.sh to set up the project."
     exit 1
 fi
 
+# Optional warning if local .venv does not exist
+if [ ! -d ".venv" ]; then
+    echo "Warning: .venv not found in project directory."
+    echo "Poetry may be using an external virtual environment."
+    echo
+fi
+
 echo "Starting application..."
 poetry run python transcribe.py
+status=$?
 
-if [ $? -ne 0 ]; then
+if [ $status -ne 0 ]; then
     echo
     echo "ERROR: Application failed to start."
     echo "Please check the error messages above."
-    exit 1
+    exit $status
 fi

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -1,6 +1,6 @@
 import unittest
 
-from env_utils import env_str, env_int, env_float, env_bool
+from env_utils import env_str, env_int, env_float, env_bool, parse_language_candidates
 
 
 class EnvUtilsTests(unittest.TestCase):
@@ -30,6 +30,36 @@ class EnvUtilsTests(unittest.TestCase):
         self.assertFalse(env_bool(env, "B", True, warnings))
         self.assertTrue(env_bool(env, "C", True, warnings))
         self.assertTrue(any("Invalid boolean" in w for w in warnings))
+
+    def test_parse_language_candidates_single(self):
+        warnings = []
+        langs = parse_language_candidates("en", ["en", "no", "lv"], warnings)
+        self.assertEqual(langs, ["en"])
+        self.assertEqual(warnings, [])
+
+    def test_parse_language_candidates_multiple(self):
+        warnings = []
+        langs = parse_language_candidates("en,no", ["en", "no", "lv"], warnings)
+        self.assertEqual(langs, ["en", "no"])
+        self.assertEqual(warnings, [])
+
+    def test_parse_language_candidates_with_invalid(self):
+        warnings = []
+        langs = parse_language_candidates("EN, no ,xx", ["en", "no", "lv"], warnings)
+        self.assertEqual(langs, ["en", "no"])
+        self.assertTrue(any("unsupported code 'xx'" in w for w in warnings))
+
+    def test_parse_language_candidates_empty_fallback(self):
+        warnings = []
+        langs = parse_language_candidates(", ,", ["en", "no", "lv"], warnings)
+        self.assertEqual(langs, ["en"])
+        self.assertTrue(any("has no supported codes" in w for w in warnings))
+
+    def test_parse_language_candidates_dedupes(self):
+        warnings = []
+        langs = parse_language_candidates("en,en,no", ["en", "no", "lv"], warnings)
+        self.assertEqual(langs, ["en", "no"])
+        self.assertEqual(warnings, [])
 
 
 if __name__ == "__main__":

--- a/transcribe.py
+++ b/transcribe.py
@@ -24,6 +24,7 @@ import assistant
 import openai_transcribe
 import audio_capture as audio_capture_module
 import ui as ui_module
+from env_utils import parse_language_candidates
 from logging_utils import setup_logging
 from transcript_store import TranscriptStore
 from transcript_filter import TranscriptFilter
@@ -107,12 +108,21 @@ LIVE_ASSISTANT_PANEL_CONFIG: list[tuple[str, str, str]] = [
     ("get_facts", "Facts", "ASSISTANT_LIVE_FACTS_ENABLED"),
 ]
 
+SUPPORTED_LANGUAGES = [
+    "en", "lv", "ru", "de", "fr", "es", "it", "pt", "nl", "pl",
+    "sv", "fi", "et", "lt", "ja", "zh", "ko", "ar", "tr", "no",
+]
+
+def _format_language_candidates(candidates: list[str]) -> str:
+    return ",".join(candidates)
+
 
 def _print_startup_summary() -> None:
     logger.info("=== Startup Configuration Summary ===")
     logger.info("Platform: %s", sys.platform)
     logger.info("User name: %s", g_my_name)
-    logger.info("Language: %s", g_language)
+    logger.info("Configured language candidates: %s", _format_language_candidates(g_language_candidates))
+    logger.info("Default active language at startup: %s", g_active_language)
     logger.info("Manual interrupt enabled: %s", g_interupt_manually)
     logger.info("Transcript model: %s", g_openai_model_for_transcript)
     logger.info("Record seconds: %s", RECORD_SECONDS)
@@ -282,7 +292,7 @@ def _create_transcript_ai() -> openai_transcribe.OpenAITranscribe:
     return openai_transcribe.OpenAITranscribe(
         model=g_openai_model_for_transcript,
         keywords=g_keywords,
-        language=g_language,
+        language=g_active_language,
         status_callback=_transcription_status_callback,
     )
 
@@ -291,7 +301,11 @@ def _reinitialize_transcript_ai() -> None:
     global g_transcript_ai
     try:
         g_transcript_ai = _create_transcript_ai()
-        logger.info("Transcription model reinitialized with language=%s model=%s", g_language, g_openai_model_for_transcript)
+        logger.info(
+            "Transcription model reinitialized with language=%s model=%s",
+            g_active_language,
+            g_openai_model_for_transcript,
+        )
     except Exception as e:
         logger.error("Failed to reinitialize transcription model: %s", e)
         set_status("Transcription reinit failed", "error")
@@ -349,8 +363,15 @@ if g_my_name == "You":
 logger.info("Your name is: %s", g_my_name)
 AGENT_NAME="Agent"
 
-g_language = _env_str("LANGUAGE", "en")
-logger.info("Language: %s", g_language)
+g_language_candidates = parse_language_candidates(
+    _env_str("LANGUAGE", "en"),
+    SUPPORTED_LANGUAGES,
+    g_startup_warnings,
+    fallback="en",
+)
+g_active_language = g_language_candidates[0]
+logger.info("Configured language candidates: %s", _format_language_candidates(g_language_candidates))
+logger.info("Default active language at startup: %s", g_active_language)
 
 g_open_api_key = _env_str("OPENAI_API_KEY")
 if not g_open_api_key:
@@ -590,8 +611,79 @@ def _sync_auto_start_var():
         _save_env_updates({"AUTO_START_TRANSCRIPTION": "True" if g_auto_start_transcription else "False"})
 
 
+def _prompt_language_selection(candidates: list[str], default_language: str) -> str | None:
+    if root is None:
+        return default_language
+    if len(candidates) <= 1:
+        return candidates[0] if candidates else default_language
+
+    theme = ui_module.THEME
+    dialog = tk.Toplevel(root)
+    dialog.title("Select Transcription Language")
+    dialog.geometry("420x180")
+    dialog.resizable(False, False)
+    dialog.transient(root)
+    dialog.grab_set()
+    dialog.configure(bg=theme["bg"])
+    ui_module.apply_dark_title_bar(dialog)
+
+    selected_var = tk.StringVar(
+        value=default_language if default_language in candidates else candidates[0]
+    )
+    selection: dict[str, str | None] = {"value": None}
+
+    tk.Label(
+        dialog,
+        text="Choose language for this recording session:",
+        bg=theme["bg"],
+        fg=theme["text_primary"],
+        font=ui_module.get_font(g_default_font_size),
+    ).pack(anchor="w", padx=16, pady=(16, 8))
+
+    ttk.Combobox(
+        dialog,
+        values=candidates,
+        textvariable=selected_var,
+        state="readonly",
+        width=20,
+    ).pack(anchor="w", padx=16, pady=(0, 16))
+
+    btn_row = tk.Frame(dialog, bg=theme["bg"])
+    btn_row.pack(fill=tk.X, padx=16, pady=(0, 12))
+
+    def on_start() -> None:
+        selection["value"] = (selected_var.get() or "").strip().lower()
+        dialog.destroy()
+
+    def on_cancel() -> None:
+        selection["value"] = None
+        dialog.destroy()
+
+    ui_module.create_styled_button(
+        btn_row,
+        text="Start",
+        command=on_start,
+        bg=theme["accent_green"],
+        hover_bg=theme["accent_green_hover"],
+        font_size=g_default_font_size,
+    ).pack(side=tk.RIGHT, padx=(6, 0))
+    ui_module.create_styled_button(
+        btn_row,
+        text="Cancel",
+        command=on_cancel,
+        bg=theme["surface_light"],
+        hover_bg=theme["surface"],
+        fg=theme["text_secondary"],
+        font_size=g_default_font_size,
+    ).pack(side=tk.RIGHT)
+
+    dialog.protocol("WM_DELETE_WINDOW", on_cancel)
+    dialog.wait_window()
+    return selection["value"]
+
+
 def _open_settings():
-    global g_language, g_auto_summarize_on_stop, g_output_dir, g_summaries_dir
+    global g_language_candidates, g_active_language, g_auto_summarize_on_stop, g_output_dir, g_summaries_dir
     global g_assistant_web_search_for_custom_prompts
     global g_my_name, g_interupt_manually, g_keywords, g_openai_model_for_transcript
     global g_agent_font_size, g_default_font_size, g_temp_dir, g_context_file
@@ -675,11 +767,17 @@ def _open_settings():
     tk.Entry(frame, textvariable=name_var, width=30, **_entry_opts).grid(row=row, column=1, sticky="w", pady=3)
     row += 1
 
-    tk.Label(frame, text="Language", **_lbl_opts).grid(row=row, column=0, sticky="w", pady=3, **pad)
-    lang_var = tk.StringVar(value=g_language or "en")
-    languages = ["en", "lv", "ru", "de", "fr", "es", "it", "pt", "nl", "pl", "sv", "fi", "et", "lt", "ja", "zh", "ko", "ar", "tr"]
-    ttk.Combobox(frame, values=languages, textvariable=lang_var, state="readonly", width=12).grid(
-        row=row, column=1, sticky="w", pady=3)
+    tk.Label(frame, text="Language(s)", **_lbl_opts).grid(row=row, column=0, sticky="w", pady=3, **pad)
+    lang_var = tk.StringVar(value=_format_language_candidates(g_language_candidates))
+    tk.Entry(frame, textvariable=lang_var, width=30, **_entry_opts).grid(row=row, column=1, sticky="w", pady=3)
+    tk.Label(
+        frame,
+        text="Use one code or comma-separated list (example: en,no).",
+        bg=theme["bg"],
+        fg=theme["text_muted"],
+        font=ui_module.get_font(max(8, g_default_font_size - 1)),
+    ).grid(row=row + 1, column=1, columnspan=2, sticky="w")
+    row += 1
     row += 1
 
     tk.Label(frame, text="Keywords", **_lbl_opts).grid(row=row, column=0, sticky="w", pady=3, **pad)
@@ -950,7 +1048,7 @@ def _open_settings():
     btn_bar.pack(side=tk.BOTTOM, fill=tk.X)
 
     def on_save():
-        global g_language, g_auto_summarize_on_stop, g_output_dir, g_summaries_dir
+        global g_language_candidates, g_active_language, g_auto_summarize_on_stop, g_output_dir, g_summaries_dir
         global g_assistant_web_search_for_custom_prompts
         global g_my_name, g_interupt_manually, g_keywords, g_openai_model_for_transcript
         global g_agent_font_size, g_default_font_size, g_temp_dir, g_context_file
@@ -958,7 +1056,16 @@ def _open_settings():
         global g_live_assistant_mode_enabled
 
         g_my_name = name_var.get().strip() or "You"
-        g_language = (lang_var.get() or "en").strip()
+        language_warnings: list[str] = []
+        g_language_candidates = parse_language_candidates(
+            (lang_var.get() or "en").strip(),
+            SUPPORTED_LANGUAGES,
+            language_warnings,
+            fallback="en",
+        )
+        g_active_language = g_language_candidates[0]
+        for warning in language_warnings:
+            logger.warning("[Settings] %s", warning)
         g_keywords = kw_var.get().strip() or None
         g_interupt_manually = bool(interrupt_var.get())
         g_auto_summarize_on_stop = bool(auto_sum_var.get())
@@ -1004,7 +1111,7 @@ def _open_settings():
 
         env_updates = {
             "YOUR_NAME": g_my_name,
-            "LANGUAGE": g_language,
+            "LANGUAGE": _format_language_candidates(g_language_candidates),
             "INTERUPT_MANUALLY": "True" if g_interupt_manually else "False",
             "AUTO_START_TRANSCRIPTION": "True" if bool(auto_start_var.get()) else "False",
             "AUTO_SUMMARIZE_ON_STOP": "True" if g_auto_summarize_on_stop else "False",
@@ -1074,11 +1181,34 @@ def _open_settings():
                                    font_size=g_default_font_size).pack(side=tk.RIGHT)
 
 
-def start_transcription():
-    global g_is_recording, g_recording_threads, g_devices_initialized
+def start_transcription(manual_start: bool = True):
+    global g_is_recording, g_recording_threads, g_devices_initialized, g_active_language
     global flush_letter_mic, flush_letter_out
     if g_is_recording:
         return
+
+    if manual_start and len(g_language_candidates) > 1:
+        selected_language = _prompt_language_selection(g_language_candidates, g_active_language)
+        if not selected_language:
+            set_status("Transcription start cancelled", "warning")
+            return
+    elif not manual_start and len(g_language_candidates) > 1:
+        selected_language = g_language_candidates[0]
+    else:
+        selected_language = g_language_candidates[0]
+
+    if selected_language != g_active_language:
+        g_active_language = selected_language
+        _reinitialize_transcript_ai()
+    else:
+        g_active_language = selected_language
+
+    logger.info(
+        "[Start] Using transcription language '%s' (candidates=%s, auto_start=%s)",
+        g_active_language,
+        _format_language_candidates(g_language_candidates),
+        not manual_start,
+    )
 
     g_devices_initialized = initialize_recording()
     if not g_devices_initialized:
@@ -1109,7 +1239,7 @@ def start_transcription():
 
     g_is_recording = True
     _update_start_stop_button()
-    set_status("Transcription started", "info")
+    set_status(f"Transcription started (language: {g_active_language})", "info")
 
 
 def stop_transcription(trigger_auto_summary: bool = True):
@@ -1133,7 +1263,7 @@ def toggle_start_stop():
     if g_is_recording:
         stop_transcription()
     else:
-        start_transcription()
+        start_transcription(manual_start=True)
 
 
 def _run_summary_before_close(transcription_snapshot: list[list]) -> None:
@@ -1784,27 +1914,31 @@ def update_screen_on_new_transcription():
 
 # Initialize Recording
 def initialize_recording():
+    p = None
     try:
-        with pyaudio.PyAudio() as p:
-            global g_device_in, g_device_out
-            if sys.platform == "win32":
-                wasapi_info = p.get_host_api_info_by_type(pyaudio.paWASAPI)
-                g_device_in = p.get_device_info_by_index(wasapi_info["defaultInputDevice"])
-                g_device_out = p.get_device_info_by_index(wasapi_info["defaultOutputDevice"])
+        p = pyaudio.PyAudio()
+        global g_device_in, g_device_out
+        if sys.platform == "win32":
+            wasapi_info = p.get_host_api_info_by_type(pyaudio.paWASAPI)
+            g_device_in = p.get_device_info_by_index(wasapi_info["defaultInputDevice"])
+            g_device_out = p.get_device_info_by_index(wasapi_info["defaultOutputDevice"])
 
-                if not g_device_out.get("isLoopbackDevice", False):
-                    for loopback in p.get_loopback_device_info_generator():
-                        if g_device_out["name"] in loopback.get("name", ""):
-                            g_device_out = loopback
-                            break
-            else:
-                # Fallback: Pick default input/output devices
-                g_device_in = p.get_default_input_device_info()
-                g_device_out = p.get_default_output_device_info()
+            if not g_device_out.get("isLoopbackDevice", False):
+                for loopback in p.get_loopback_device_info_generator():
+                    if g_device_out["name"] in loopback.get("name", ""):
+                        g_device_out = loopback
+                        break
+        else:
+            # Fallback: Pick default input/output devices
+            g_device_in = p.get_default_input_device_info()
+            g_device_out = p.get_default_output_device_info()
         logger.info("[Init] Devices initialized successfully. Recording device: %s Output device: %s", g_device_in["name"], g_device_out["name"])
     except Exception as e:
         logger.error("[Init] Error initializing devices: %s", e)
         return False
+    finally:
+        if p is not None:
+            p.terminate()
     return True
 
 def handler(signum, frame):
@@ -1822,7 +1956,7 @@ def main():
 
     _update_start_stop_button()
     if g_auto_start_transcription:
-        root.after(100, start_transcription)
+        root.after(100, lambda: start_transcription(manual_start=False))
 
     try:
         logger.info("[Main] Starting Tkinter main loop...")


### PR DESCRIPTION
## Summary
- stabilize macOS recording lifecycle by hardening stream/device init and teardown paths
- add multi-language transcription configuration via `LANGUAGE` comma-separated candidates
- add per-session language selection on manual start; keep deterministic first-language selection for auto-start
- improve startup/status logging to expose configured language candidates and active language

## Why
- fixes failure-prone audio capture edge cases (zero-channel device, unclosed stream, dropped buffered frames on stop)
- enables teams that switch meeting languages to choose language at session start without editing env every time

## Changes
- `audio_capture.py`
  - skip devices with no input channels instead of crashing
  - explicit `stream` lifecycle management (`stop_stream`/`close` in `finally`)
  - flush buffered frames when stop is requested
- `transcribe.py`
  - introduce supported language set + parsing through `parse_language_candidates`
  - track `g_language_candidates` and session `g_active_language`
  - add manual start language picker dialog when multiple candidates are configured
  - auto-start uses first configured language without prompt
  - reinitialize transcript model when active language changes
  - terminate temporary PyAudio instance during device initialization
- `env_utils.py`
  - add `parse_language_candidates(...)` with dedupe, unsupported-code warnings, and fallback behavior
- `README.md` / `env.sample`
  - document single vs comma-separated `LANGUAGE` values and auto-start behavior
- `tests/test_env_utils.py`
  - add coverage for language candidate parsing edge cases

## Verification
- `python3 -m unittest -q tests/test_env_utils.py` ✅ (9 tests)
- `python3 -m pytest -q` ⚠️ not run in this environment (`pytest` module missing)

## Risks / Review Focus
- tkinter language selection modal should not block/behave unexpectedly on different OS window managers
- no dedicated automated tests yet for `start_transcription(manual_start=...)` behavior transitions
- verify macOS runtime behavior manually: start/stop repeatedly, mute/unmute, and auto-start mode
